### PR TITLE
Update to pycryptodome

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -2,12 +2,13 @@
 This tool securely password-protects HTML files from the command line using Python3.
 
 ### Usage ###
+Run: `pip3 install -r requirements.txt` 
 Run: `python3 encrypt.py filename [passphrase]`  
 The first, mandatory parameter is the name of the file you want to encrypt.
 It is also possible to give the passphrase as the second parameter. If there is
 no passphrase provided at start, the script will ask for it while running.
 
 ### Dependencies ###
-1) Python3
-2) [pycrypto](https://pypi.org/project/pycrypto/) for AES: `pip3 install pycrypto`
+1) Python3 and Pip3
+2) [pycryptodome](https://pypi.org/project/pycryptodome/) for AES. (pycrypto is [deprecated](https://github.com/pycrypto/pycrypto/issues/275))
 3) Python version of [pbkdf2](https://pypi.org/project/pbkdf2/): `pip3 install pbkdf2`

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,2 @@
+pycryptodome==3.9.9
+pbkdf2==1.3


### PR DESCRIPTION
Hi!

Pycrypto is deprecated. Switching to pycryptodome is straightforward.

I also updated the script documentation in python.

Cheers!